### PR TITLE
Pause menu (ESC) with Up/Down+Enter; adjust hitbox shrink (enemy=0.32, projectile=0.15)

### DIFF
--- a/src/main/java/com/example/demo/level/LevelParent.java
+++ b/src/main/java/com/example/demo/level/LevelParent.java
@@ -32,7 +32,7 @@ import javafx.scene.Node;
 public abstract class LevelParent extends Observable {
 
 	private static final double PLAYER_SHRINK     = 0.40; // more forgiving for the player
-	private static final double ENEMY_SHRINK      = 0.33; // fair for enemies
+	private static final double ENEMY_SHRINK      = 0.32; // fair for enemies
 	private static final double PROJECTILE_SHRINK = 0.15; // tiny trim for bullets
 
 	private static final double SCREEN_HEIGHT_ADJUSTMENT = 150;


### PR DESCRIPTION
Adds an in-game pause menu and improves keyboard UX:
- ESC toggles pause.
- Up/Down arrows move selection; Enter activates the focused/hovered item.
- Hover + Enter also activates the hovered item.
Menu items: Resume / Restart Level / Main Menu / Quit.